### PR TITLE
added the jinja2 specific version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
       - run:
           name: Installing all Dependencies
           command: |
+            pip install 'jinja2==3.0.0'
             pip install 'mkdocs==1.0.4'
       - run:
           name: convert markdown to html


### PR DESCRIPTION
By default mkdocs is downloading the jinja2==3.1.0 version which was causing the incompatibility issue.
After downgrading the jinja2 version , isssue is solved