### PR TITLE
add polly-python root folder to mkdocs path

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ plugins:
         python:
           paths:
             - ./temp_dir/polly-python/polly
+            - ./temp_dir/polly-python
           options:
             show_root_full_path: False
   - multirepo


### PR DESCRIPTION
This is needed so that classes and function from other folders in polly-python (e.g. `polly-python/polly_services`) can also be included in the docs.